### PR TITLE
排除./combine/all.txt

### DIFF
--- a/.github/workflows/combine-rules.yml
+++ b/.github/workflows/combine-rules.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Combine txt files
       run: |
         # Combine all .txt files except combine/alltmp.txt to avoid recursion
-        find . -name "*.txt" ! -path "./combine/alltmp.txt" -exec cat {} + > combine/alltmp.txt
+        find . -name "*.txt" ! -path "./combine/alltmp.txt" ! -path "./combine/all.txt" -exec cat {} + > combine/alltmp.txt
         sort -u  combine/alltmp.txt -o combine/all.txt
         # awk '!seen[$0]++' combine/alltmp.txt > combine/all.txt
 


### PR DESCRIPTION
fix #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted file selection in the combining process to prevent data duplication by excluding both `combine/alltmp.txt` and `combine/all.txt` from the concatenation of `.txt` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->