### PR TITLE
Cleanup: Remove deprecated datetime.utcnow()

### DIFF
--- a/.github/workflows/combine-rules.yml
+++ b/.github/workflows/combine-rules.yml
@@ -12,8 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-
+      uses: actions/checkout@v4
 
     - name: Create combine directory
       run: mkdir -p combine

--- a/tools/combine.py
+++ b/tools/combine.py
@@ -1,6 +1,7 @@
-import glob, ipaddress
+import glob
+import ipaddress
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 
 ipv4_prefix = 24
 ipv6_prefix = 56
@@ -18,7 +19,7 @@ ipv6_prefix_counter = Counter()
 
 for name in glob.glob("*.txt"):
     with open(name, encoding='utf-8') as f:
-        for l in f.readlines():
+        for l in f:
             line = l.strip()
             if line.startswith("#") or len(line) <= 2:
                 continue
@@ -46,11 +47,11 @@ for ip, count in ipv6_prefix_counter.most_common():
         break
 
 with open("combine/all.txt", "w", encoding='utf-8') as f:
-    f.write(header.format(time = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC'), ipv4_prefix=ipv4_prefix, ipv6_prefix=ipv6_prefix))
-    
-    for ip in ipaddress.collapse_addresses([ipaddress.ip_network(x) for x in ipv4_blocklist.keys()]):
+    f.write(header.format(time=datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S %Z'), ipv4_prefix=ipv4_prefix, ipv6_prefix=ipv6_prefix))
+
+    for ip in ipaddress.collapse_addresses([ipaddress.ip_network(x) for x in ipv4_blocklist]):
         f.write(str(ip.network_address) if ip.prefixlen == 32 else str(ip))
         f.write("\n")
-    for ip in ipaddress.collapse_addresses([ipaddress.ip_network(x) for x in ipv6_blocklist.keys()]):
+    for ip in ipaddress.collapse_addresses([ipaddress.ip_network(x) for x in ipv6_blocklist]):
         f.write(str(ip.network_address) if ip.prefixlen == 128 else str(ip))
         f.write("\n")


### PR DESCRIPTION
- Use timezone-aware objects instead of hardcoding.
- bump actions/checkout from 3 to 4

- [x] Passed the CI test. https://github.com/startgenshin/BTN-Collected-Rules/actions/runs/11666735126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 更新了工作流配置，使用新版的checkout动作以提高仓库检出步骤的可靠性。
  
- **新功能**
	- 改进了日期处理，确保时间戳包含时区信息，增强了输出的准确性。
	- 优化了内存效率，简化了文件行读取逻辑，提升了性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->